### PR TITLE
Add a Cons trait and implement First, Second, Third in terms of it.

### DIFF
--- a/benches/sequence.rs
+++ b/benches/sequence.rs
@@ -1,0 +1,37 @@
+#![feature(test)]
+extern crate test;
+extern crate tool;
+
+use tool::sequence::*;
+
+#[bench]
+fn bench_first_slice(b: &mut test::Bencher) {
+    let v = vec![1,2,3,4,5,6,7,8,9,10];
+    b.iter(|| {
+        test::black_box(first(test::black_box(&*v)))
+    })
+}
+
+#[bench]
+fn bench_third_slice(b: &mut test::Bencher) {
+    let v = vec![1,2,3,4,5,6,7,8,9,10];
+    b.iter(|| {
+        test::black_box(third(test::black_box(&*v)).unwrap())
+    })
+}
+
+#[bench]
+fn bench_first_tuple(b: &mut test::Bencher) {
+    let v = ("a", "b", "c", "d");
+    b.iter(|| {
+        test::black_box(first(test::black_box(v)))
+    })
+}
+
+#[bench]
+fn bench_third_tuple(b: &mut test::Bencher) {
+    let v = ("a", "b", "c", "d");
+    b.iter(|| {
+        test::black_box(third(test::black_box(v)))
+    })
+}


### PR DESCRIPTION
E.g., `second` is `seq.uncons().1.uncons().0`.

@bluss,

Do you think this is worth it or is it too confusing. Also, is it worth it to
keep the `First`, `Second`, and `Third` definitions?
