### PR TITLE
Update travis configuration to test from Rust 1.31, and fix warnings for missing dyn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
   - stable
   # and the first stable one (this should be bumped as the minimum
   # Rust version required changes)
-  - 1.7.0
+  - 1.31.1
 
 # load travis-cargo
 before_script:

--- a/src/functor.rs
+++ b/src/functor.rs
@@ -48,7 +48,7 @@ pub fn flip<F, A, B, R>(f: F) -> impl Fn(B, A) -> R
 /// assert_eq!(55, fib(10));
 /// ```
 pub fn fix<A, B, F>(f: F) -> impl Fn(A) -> B
-    where F: Fn(&Fn(A)-> B, A) -> B
+    where F: Fn(&dyn Fn(A)-> B, A) -> B
 {
     use std::cell::Cell;
 
@@ -56,9 +56,9 @@ pub fn fix<A, B, F>(f: F) -> impl Fn(A) -> B
         // Hopefully optimized away. Can probably use some unsafe magic to help the optimizer...
         let tmp_fn = |_: A| -> B { panic!("Hmm... not good.") };
         let (fun_holder, fun);
-        fun_holder = Cell::new(&tmp_fn as &Fn(A) -> B);
+        fun_holder = Cell::new(&tmp_fn as &dyn Fn(A) -> B);
         fun = |ai: A| { f(fun_holder.get(), ai) };
-        fun_holder.set(&fun as &Fn(A) -> B);
+        fun_holder.set(&fun as &dyn Fn(A) -> B);
         f(fun_holder.get(), a)
     }
 }


### PR DESCRIPTION
Rust 1.26 had impl Trait, so we need at least that.
Rust 2018 started with 1.31, so it seems like a good stepping stone for
now.

Also fix warnings for "dyn Trait".